### PR TITLE
refactor: Remove deprecated ::set-output command

### DIFF
--- a/.github/workflows/fetch-data.yml
+++ b/.github/workflows/fetch-data.yml
@@ -36,7 +36,7 @@ jobs:
         id: status
         run: |
           if [ -n "$(git status --porcelain)" ]; then
-            echo "::set-output name=has_changes::1"
+            echo "has_changes=1" >> $GITHUB_OUTPUT
           fi
       - name: Commit changes
         if: steps.status.outputs.has_changes == '1'

--- a/.github/workflows/fetch-maintained.yml
+++ b/.github/workflows/fetch-maintained.yml
@@ -36,7 +36,7 @@ jobs:
         id: status
         run: |
           if [ -n "$(git status --porcelain)" ]; then
-            echo "::set-output name=has_changes::1"
+            echo "has_changes=1" >> $GITHUB_OUTPUT
           fi
       - name: Commit changes
         if: steps.status.outputs.has_changes == '1'

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -49,11 +49,11 @@ jobs:
         run: |
           dependabot_dir="${{ steps.metadata.outputs.directory }}"
           if [[ "$dependabot_dir" == "/" ]]; then
-            echo "::set-output name=workspace::-iwr"
+            echo "workspace=-iwr" >> $GITHUB_OUTPUT
           else
             # strip leading slash from directory so it works as a
             # a path to the workspace flag
-            echo "::set-output name=workspace::-w ${dependabot_dir#/}"
+            echo "workspace=-w ${dependabot_dir#/}" >> $GITHUB_OUTPUT
           fi
 
       - name: Apply Changes
@@ -62,7 +62,7 @@ jobs:
         run: |
           npm run template-oss-apply ${{ steps.flags.outputs.workspace }}
           if [[ `git status --porcelain` ]]; then
-            echo "::set-output name=changes::true"
+            echo "changes=true" >> $GITHUB_OUTPUT
           fi
           # This only sets the conventional commit prefix. This workflow can't reliably determine
           # what the breaking change is though. If a BREAKING CHANGE message is required then
@@ -72,7 +72,7 @@ jobs:
           else
             prefix='chore'
           fi
-          echo "::set-output name=message::$prefix: postinstall for dependabot template-oss PR"
+          echo "message=$prefix: postinstall for dependabot template-oss PR" >> $GITHUB_OUTPUT
 
       # This step will fail if template-oss has made any workflow updates. It is impossible
       # for a workflow to update other workflows. In the case it does fail, we continue


### PR DESCRIPTION
### Proposed Changes

- Replace the deprecated `::set-output` workflow commands.
  See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.

